### PR TITLE
Code Cleanup

### DIFF
--- a/bin/theia
+++ b/bin/theia
@@ -62,7 +62,6 @@ def cliargopts():
    if optflags['debug']: stderr.write("%s: debug: %s\n%s: debug: filer: %s (%s)\n" % (ME,optflags,ME,filer,hostname))
 
    return(optflags,filer,hostname)
-   oscheck(hostname)
    vifautodiscover(hostname)
 
 def send_nsca(hostname,svc_descr,rt,svc_output):
@@ -409,8 +408,6 @@ class NAPStat(XNSysStat):
    _valueunits = staticmethod(_valueunits)
 
    def vifautodiscover(hostname):
-      if_list = []
-      vifs = []
       # Read active network interfaces into python tuple
       cmd = "/usr/bin/ssh -o BatchMode=yes -2 -ax -i %s %s 'stats show ifnet'|sed 's/:/ /g'|sort|awk '{print $2}'|uniq|tr -d '\r'" % (sshkeyfile,hostname)
       p = subprocess.Popen(cmd,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
@@ -427,16 +424,6 @@ class NAPStat(XNSysStat):
       for vif in vifs:
          xnmetrics["NetRE %s" % (vif)] = "ifnet:%s:recv_errors" % (vif)
          xnmetrics["NetSE %s" % (vif)] = "ifnet:%s:send_errors" % (vif)
-
-   def oscheck(hostname):
-      #7.3.1.1
-      cmd = "/usr/bin/ssh -o BatchMode=yes -2 -ax -i %s %s 'version'|awk '{print $3}'|sed 's/://g'" % (sshkeyfile,hostname)
-      p = subprocess.Popen(cmd,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-      so = p.communicate()[0]
-      os = so.rstrip('\n')
-      if os != "7.3.1.1":
-         print "Theia has only been tested on ONTAP 7.3. You are running: %s" % (os)
-
 
    def Initialize(cls,filer,options={}):
       


### PR DESCRIPTION
Code cleanup. Removed unused code and the oscheck function since support for ONTAP8 was implemented in the last commit.
